### PR TITLE
Persist language selection across pages

### DIFF
--- a/api.html
+++ b/api.html
@@ -393,10 +393,16 @@ POST https://your.app/hooks/gasfree
         const key=node.getAttribute('data-i18n');
         if(I18N[lang] && I18N[lang][key]) node.textContent = I18N[lang][key];
       });
+      try{ localStorage.setItem('lang', lang); }catch(e){}
+    }
+    function detectLang(){
+      const nav = (navigator.language||'').slice(0,2).toLowerCase();
+      return ['ru','en','zh'].includes(nav) ? nav : 'en';
     }
     document.querySelectorAll('.flag').forEach(f=>f.addEventListener('click',()=>setLang(f.dataset.lang)));
     document.getElementById('y').textContent = new Date().getFullYear();
-    setLang('en');
+    const savedLang = localStorage.getItem('lang');
+    setLang(savedLang || detectLang());
   </script>
 </body>
 </html>

--- a/how-it-works.html
+++ b/how-it-works.html
@@ -441,7 +441,12 @@
     if(scenarioSel){ scenarioSel.addEventListener('change', recalc); }
 
     var saved = null; try{ saved = localStorage.getItem('lang'); }catch(e){}
-    setLang(saved || 'ru');
+    if(!saved){
+      var nav = (navigator.language||'').slice(0,2).toLowerCase();
+      saved = ['ru','en','zh'].indexOf(nav)>=0 ? nav : 'en';
+      try{ localStorage.setItem('lang', saved); }catch(e){}
+    }
+    setLang(saved);
 
     var flags = document.querySelectorAll('.flag');
     for(var i=0;i<flags.length;i++){

--- a/index_03.html
+++ b/index_03.html
@@ -499,8 +499,15 @@
     };
 
     const $ = id => document.getElementById(id);
-    // По умолчанию пусть будет RU (соответствует активной кнопке)
-    let lang = localStorage.getItem('energy_lang') || 'ru';
+    function detectLang(){
+      const nav = (navigator.language || '').slice(0,2).toLowerCase();
+      return ['ru','en','zh'].includes(nav) ? nav : 'en';
+    }
+    let lang = localStorage.getItem('lang');
+    if(!lang){
+      lang = detectLang();
+      try{ localStorage.setItem('lang', lang); }catch(e){}
+    }
 
     // Константы
     const PAY_TO_ADDRESS="TDmt2ieRw2YsvTERcQmth3H4kCHqsPHArp";
@@ -609,7 +616,7 @@
           const newLang = btn.dataset.lang;
           if(!newLang || !I18N[newLang]) return;
           lang = newLang;
-          localStorage.setItem('energy_lang', lang);
+          try{ localStorage.setItem('lang', lang); }catch(e){}
           setActiveFlag(); applyText();
         });
       });


### PR DESCRIPTION
## Summary
- Detect browser language and persist choice using a shared `lang` key
- Apply stored language across `api.html`, `how-it-works.html`, and `index_03.html`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d9c1f780832f995f505ad8f4f5cc