### PR TITLE
Add partner outreach block to index page

### DIFF
--- a/index_03.html
+++ b/index_03.html
@@ -250,6 +250,27 @@
       </div>
     </section>
 
+    <!-- Partner block -->
+    <section class="faq" id="biz">
+      <h3 class="title" style="font-size:22px" data-i18n="biz_title">Партнёрам и большим объёмам</h3>
+      <details>
+        <summary data-i18n="biz_q1">Большие объёмы и хотите экономить больше?</summary>
+        <p data-i18n="biz_a1">Свяжитесь с нами в <a href='https://t.me/saving_trx_bot' target='_blank' rel='noopener'>Telegram</a> — предложим индивидуальные условия.</p>
+      </details>
+      <details>
+        <summary data-i18n="biz_q2">Нужно раздавать энергию на другие кошельки?</summary>
+        <p data-i18n="biz_a2">У нас есть UI и API для этого. <a href='https://t.me/saving_trx_bot' target='_blank' rel='noopener'>Свяжитесь с нами</a>.</p>
+      </details>
+      <details>
+        <summary data-i18n="biz_q3">Хотите свой бизнес?</summary>
+        <p data-i18n="biz_a3"><a href='https://t.me/saving_trx_bot' target='_blank' rel='noopener'>Свяжитесь с нами</a> — поможем стартовать.</p>
+      </details>
+      <details>
+        <summary data-i18n="biz_q4">Есть аудитория и хотите помочь ей экономить и зарабатывать?</summary>
+        <p data-i18n="biz_a4"><a href='https://t.me/saving_trx_bot' target='_blank' rel='noopener'>Свяжитесь с нами</a> — у нас есть партнёрская программа.</p>
+      </details>
+    </section>
+
     <!-- Mini SEO note -->
     <p class="seo-inline" data-i18n="seo_inline">
       <strong>GasFree4you.com</strong> — если встретите запрос <em>gasfree4ucom</em>, это обычная опечатка и тоже про нас.
@@ -412,6 +433,15 @@
         a5:"Да. Есть UI для массовой раздачи и REST API. Жмите «API» в шапке.",
         q6: "Я видел «gasfree4ucom» — это вы?",
         a6: "Нет. «gasfree4ucom» — это другой сервис с похожими условиями. Энергию TRON можно купить там, где вам удобно — у нас или в любом другом месте.",
+        biz_title:"Партнёрам и большим объёмам",
+        biz_q1:"Большие объёмы и хотите экономить больше?",
+        biz_a1:"Свяжитесь с нами в <a href='https://t.me/saving_trx_bot' target='_blank' rel='noopener'>Telegram</a> — предложим индивидуальные условия.",
+        biz_q2:"Нужно раздавать энергию на другие кошельки?",
+        biz_a2:"У нас есть UI и API для этого. <a href='https://t.me/saving_trx_bot' target='_blank' rel='noopener'>Свяжитесь с нами</a>.",
+        biz_q3:"Хотите свой бизнес?",
+        biz_a3:"<a href='https://t.me/saving_trx_bot' target='_blank' rel='noopener'>Свяжитесь с нами</a> — поможем стартовать.",
+        biz_q4:"Есть аудитория и хотите помочь ей экономить и зарабатывать?",
+        biz_a4:"<a href='https://t.me/saving_trx_bot' target='_blank' rel='noopener'>Свяжитесь с нами</a> — у нас есть партнёрская программа.",
         meta_title:"Аренда энергии TRON — GasFree4you",
         meta_desc:"GasFree4you.com (часто ищут как «gasfree4ucom»): энергия TRON для переводов USDT/TRC20 с почти нулевой комиссией TRX. Энергия на один перевод.",
         seo_inline:"<strong>GasFree4you.com</strong> — если встретили <em>gasfree4ucom</em>, это другой сервис с похожими условиями. Энергию TRON можно купить в любом месте, где вам удобно."
@@ -452,6 +482,15 @@
         a5:"Yes. UI for bulk distribution and a REST API. See the “API” button above.",
         q6: "I saw “gasfree4ucom” — is that you?",
         a6: "No. “gasfree4ucom” is a different service with similar conditions. You’re free to buy TRON energy wherever you prefer — from us or anywhere else." ,
+        biz_title:"For volumes and partners",
+        biz_q1:"Large volumes and want to save more?",
+        biz_a1:"Contact us on <a href='https://t.me/saving_trx_bot' target='_blank' rel='noopener'>Telegram</a> for custom rates.",
+        biz_q2:"Need to distribute energy to other wallets?",
+        biz_a2:"We have an interface and API. <a href='https://t.me/saving_trx_bot' target='_blank' rel='noopener'>Reach out</a>.",
+        biz_q3:"Want your own business?",
+        biz_a3:"<a href='https://t.me/saving_trx_bot' target='_blank' rel='noopener'>Contact us</a> and we’ll help you launch.",
+        biz_q4:"Have an audience and want to help them save and earn?",
+        biz_a4:"<a href='https://t.me/saving_trx_bot' target='_blank' rel='noopener'>Get in touch</a> — partner program available.",
           meta_title:"Rent TRON Energy — GasFree4you",
         meta_desc:"GasFree4you.com (often searched as 'gasfree4ucom'): TRON energy for USDT/TRC20 zero-fee transfers. One-transfer energy.",
         seo_inline:"<strong>GasFree4you.com</strong> — if you saw <em>gasfree4ucom</em>, note that it’s a different service with similar conditions. You are free to buy TRON energy anywhere."
@@ -492,6 +531,15 @@
         a5:"提供。上方点击“API”。",
         q6: "我看到“gasfree4ucom”，是你们吗？",
         a6: "不是。“gasfree4ucom”是另一个与我们条件相似的服务。TRON 能量可在任意平台购买——可以选择我们，也可以选择其他渠道。",
+        biz_title:"更多场景与合作",
+        biz_q1:"大额需求想节省更多？",
+        biz_a1:"通过 <a href='https://t.me/saving_trx_bot' target='_blank' rel='noopener'>Telegram</a> 联系我们，可获得定制价格。",
+        biz_q2:"需要向其他钱包分发能量？",
+        biz_a2:"我们提供界面和 API。<a href='https://t.me/saving_trx_bot' target='_blank' rel='noopener'>欢迎联系</a>。",
+        biz_q3:"想开展自己的业务？",
+        biz_a3:"<a href='https://t.me/saving_trx_bot' target='_blank' rel='noopener'>联系我们</a>，我们会协助启动。",
+        biz_q4:"有自己的用户想帮他们省钱并赚钱？",
+        biz_a4:"<a href='https://t.me/saving_trx_bot' target='_blank' rel='noopener'>联系我们</a>——提供合作计划。",
         meta_title:"租用 TRON 能量 — GasFree4you",
         meta_desc:"GasFree4you.com（有时被写成“gasfree4ucom”）：用于 USDT/TRC20 的 TRON 能量，几乎零 TRX 手续费，一次性转账能量。",
        seo_inline:"<strong>GasFree4you.com</strong> —— 如果你看到 <em>gasfree4ucom</em>，那是另一个有类似条件的服务。TRON 能量可在任何地方购买，自由选择。"


### PR DESCRIPTION
## Summary
- add collapsible partner block before FAQ on `index_03.html`
- localize partner block content for Russian, English, and Chinese

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8dcf6b454832fad13917558fa2564