### PR TITLE
Add business TRON energy page with staking info

### DIFF
--- a/business.html
+++ b/business.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <title data-i18n-head="title">GasFree4you — TRON Energy for Business</title>
+  <meta name="description" content="Dashboard, API and automated TRON energy top-ups for businesses" data-i18n-head="desc"/>
+  <meta name="theme-color" content="#0b1020">
+  <link rel="icon" type="image/png" href="/favicon.png">
+  <style>
+    :root{--bg:#0b1020; --card:#0f152a; --text:#eaf2ff; --muted:#9db1c4; --accent:#6ee7ff; --accent2:#7df1b7; --border:rgba(255,255,255,.1); --radius:18px; --ring:rgba(110,231,255,.28);}
+    body{margin:0;font-family:system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;background:var(--bg);color:var(--text);line-height:1.5;padding:16px;}
+    a{color:var(--accent);}
+    header{display:flex;justify-content:flex-end;gap:8px;margin-bottom:16px;}
+    .flag{cursor:pointer;padding:4px 8px;border:1px solid var(--border);border-radius:4px;background:var(--card);}
+    .flag[aria-pressed="true"]{border-color:var(--accent);}
+    h1,h2{color:var(--accent2);margin-top:24px;}
+    ul{padding-left:20px;}
+    table{border-collapse:collapse;margin-top:8px;}
+    th,td{border:1px solid var(--border);padding:8px 12px;}
+    th{background:var(--card);}    
+    img{max-width:100%;height:auto;margin:12px 0;}
+  </style>
+</head>
+<body>
+<header>
+  <span class="flag" data-lang="en" aria-pressed="true">EN</span>
+  <span class="flag" data-lang="ru">RU</span>
+  <span class="flag" data-lang="zh">中文</span>
+</header>
+<main>
+  <h1 data-i18n="h1">TRON Energy for Business</h1>
+  <section>
+    <h2 data-i18n="feat_title">Our capabilities</h2>
+    <ul>
+      <li data-i18n="feat1">Energy distribution dashboard</li>
+      <li data-i18n="feat2">API for integration into existing systems</li>
+      <li data-i18n="feat3">Maintaining constant energy levels on wallets so you don’t have to think about delegation</li>
+    </ul>
+  </section>
+  <section>
+    <h2 data-i18n="benefit_title">Why delegate energy</h2>
+    <p data-i18n="benefit_text">A single transfer normally costs 13 TRX if the recipient wallet has USDT or 27 TRX if not. With our service price is 3 TRX and 6 TRX respectively. 1 TRX = 0.35 USDT.</p>
+  </section>
+  <section>
+    <h2 data-i18n="stake_title">Staking facts</h2>
+    <ul>
+      <li data-i18n="stake1">By staking TRX, you can obtain free resources on the network to cover the fee of transactions. The resources used will dynamically recover to the original amount after a certain period.</li>
+      <li data-i18n="stake2">You may delegate idle resources to others and can reclaim the resources anytime.</li>
+    </ul>
+    <img src="images/stake.svg" alt="Stake TRX diagram">
+    <img src="images/delegate.svg" alt="Delegate resources diagram">
+  </section>
+  <section>
+    <h2 data-i18n="discount_title">Volume discounts</h2>
+    <table>
+      <tr><th data-i18n="vol_header">Volume per month</th><th data-i18n="disc_header">Discount</th></tr>
+      <tr><td>&ge;10</td><td>2%</td></tr>
+      <tr><td>&ge;50</td><td>5%</td></tr>
+      <tr><td>&ge;100</td><td>10%</td></tr>
+    </table>
+  </section>
+</main>
+<script>
+const I18N = {
+  en:{
+    head:{title:"GasFree4you — TRON Energy for Business",desc:"Dashboard, API and automated TRON energy top-ups for businesses"},
+    h1:"TRON Energy for Business",
+    feat_title:"Our capabilities",
+    feat1:"Energy distribution dashboard",
+    feat2:"API for integration into existing systems",
+    feat3:"Maintaining constant energy levels on wallets so you don’t have to think about delegation",
+    benefit_title:"Why delegate energy",
+    benefit_text:"A single transfer normally costs 13 TRX if the recipient wallet has USDT or 27 TRX if not. With our service price is 3 TRX and 6 TRX respectively. 1 TRX = 0.35 USDT.",
+    stake_title:"Staking facts",
+    stake1:"By staking TRX, you can obtain free resources on the network to cover the fee of transactions. The resources used will dynamically recover to the original amount after a certain period.",
+    stake2:"You may delegate idle resources to others and can reclaim the resources anytime.",
+    discount_title:"Volume discounts",
+    vol_header:"Volume per month",
+    disc_header:"Discount"
+  },
+  ru:{
+    head:{title:"GasFree4you — Энергия TRON для бизнеса",desc:"Кабинет, API и автоматическое поддержание энергии для компаний"},
+    h1:"Энергия TRON для бизнеса",
+    feat_title:"Наши возможности",
+    feat1:"Кабинет для распределения энергии",
+    feat2:"API для встраивания в существующие системы",
+    feat3:"Поддержание постоянного уровня энергии на кошельках, чтобы не думать о делегировании",
+    benefit_title:"Выгода от делегирования энергии",
+    benefit_text:"Для одного перевода нужно 13 TRX если на кошельке получателя есть USDT или 27 TRX если нет. С нашим сервисом цена будет 3 TRX и 6 TRX соответственно. 1 TRX = 0.35 USDT.",
+    stake_title:"Информация о стейкинге",
+    stake1:"Замораживая TRX, вы получаете бесплатные ресурсы сети для покрытия комиссии. Использованные ресурсы со временем восстанавливаются.",
+    stake2:"Вы можете делегировать свободные ресурсы другим и забрать их обратно в любое время.",
+    discount_title:"Система скидок",
+    vol_header:"Объём в месяц",
+    disc_header:"Скидка"
+  },
+  zh:{
+    head:{title:"GasFree4you — 面向企业的 TRON 能量",desc:"面板、API 和自动能量补充"},
+    h1:"适用于企业的 TRON 能量",
+    feat_title:"我们的能力",
+    feat1:"用于分配能量的控制面板",
+    feat2:"可嵌入现有系统的 API",
+    feat3:"保持钱包能量恒定，无需再考虑委托",
+    benefit_title:"使用能量委托的优势",
+    benefit_text:"一次转账通常需要 13 TRX（若收款钱包已有 USDT）或 27 TRX（否则）。通过我们的服务仅需 3 TRX 或 6 TRX。1 TRX = 0.35 USDT。",
+    stake_title:"质押信息",
+    stake1:"质押 TRX 可获得免费资源以支付交易费用，消耗的资源会在一段时间后恢复。",
+    stake2:"可将空闲资源委托给他人，并可随时收回。",
+    discount_title:"折扣体系",
+    vol_header:"每月数量",
+    disc_header:"折扣"
+  }
+};
+function setLang(l){
+  const dict=I18N[l]||I18N.en;
+  document.querySelectorAll('[data-i18n]').forEach(el=>{
+    const key=el.getAttribute('data-i18n');
+    if(dict[key]) el.textContent=dict[key];
+  });
+  const head=dict.head||{};
+  if(head.title) document.title=head.title;
+  if(head.desc) document.querySelector('meta[name="description"]').setAttribute('content',head.desc);
+  document.documentElement.lang=l;
+  document.querySelectorAll('.flag').forEach(b=>b.setAttribute('aria-pressed',b.dataset.lang===l?'true':'false'));
+  try{localStorage.setItem('biz_lang',l);}catch(e){}
+}
+function init(){
+  const saved=localStorage.getItem('biz_lang');
+  const lang=saved&&I18N[saved]?saved:'en';
+  setLang(lang);
+  document.querySelectorAll('.flag').forEach(btn=>btn.addEventListener('click',()=>setLang(btn.dataset.lang)));
+}
+init();
+</script>
+</body>
+</html>

--- a/images/delegate.svg
+++ b/images/delegate.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 200" width="600" height="200">
+  <style>
+    text{font-family:Arial, sans-serif;font-size:14px;fill:#000}
+    .icon{font-size:20px}
+    .person{fill:#fff;stroke:#000;stroke-width:1}
+  </style>
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="10" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L10,3 L0,6 Z" fill="#000" />
+    </marker>
+  </defs>
+  <circle cx="120" cy="100" r="40" class="person"/>
+  <text x="105" y="107">You</text>
+  <circle cx="480" cy="100" r="40" class="person"/>
+  <text x="460" y="107">Others</text>
+  <path d="M160,80 C260,20 340,20 440,80" stroke="#000" stroke-width="2" fill="none" marker-end="url(#arrow)"/>
+  <text x="250" y="40">Delegate Resources</text>
+  <path d="M440,120 C340,180 260,180 160,120" stroke="#000" stroke-width="2" fill="none" marker-end="url(#arrow)"/>
+  <text x="250" y="190">Reclaim Resources</text>
+</svg>

--- a/images/stake.svg
+++ b/images/stake.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 180" width="600" height="180">
+  <style>
+    text{font-family:Arial, sans-serif;font-size:14px;fill:#000}
+    .box{fill:#fff;stroke:#000;stroke-width:1}
+    .icon{font-size:20px}
+  </style>
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="10" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L10,3 L0,6 Z" fill="#000" />
+    </marker>
+  </defs>
+  <rect x="20" y="60" width="120" height="60" class="box"/>
+  <text x="40" y="95">Stake TRX</text>
+  <line x1="140" y1="90" x2="230" y2="90" stroke="#000" stroke-width="2" marker-end="url(#arrow)"/>
+  <rect x="230" y="20" width="170" height="60" class="box"/>
+  <text x="240" y="55">Get Energy</text>
+  <text x="390" y="50" class="icon">🔋</text>
+  <rect x="230" y="100" width="170" height="60" class="box"/>
+  <text x="240" y="135">Get Bandwidth</text>
+  <text x="390" y="130" class="icon">⚡</text>
+  <text x="230" y="15" font-size="12">All contract calls consume Energy</text>
+  <text x="230" y="175" font-size="12">All transactions consume Bandwidth</text>
+</svg>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -15,4 +15,9 @@
     <lastmod>2025-08-15</lastmod>
     <priority>0.80</priority>
   </url>
+  <url>
+    <loc>https://gasfree4you.com/business.html</loc>
+    <lastmod>2025-08-15</lastmod>
+    <priority>0.80</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary
- add multilingual business page describing capabilities, pricing savings and staking benefits
- include volume discount table and staking diagrams
- register the new page in sitemap

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1da636bc832fa7c0537364d5978a